### PR TITLE
Version: 1.2.7

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import './App.css';
 import React, { useState, useEffect, useRef } from 'react';
 import io from 'socket.io-client';
 
+import { googleLogout } from '@react-oauth/google';
 import GoogleSignIn from './GoogleSignIn';
 import EmojiPicker from 'emoji-picker-react';
 import { getSocketUrl } from './socket';
@@ -66,6 +67,21 @@ function App() {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  useEffect(() => {
+    const savedSession = localStorage.getItem('chatSession');
+    if (savedSession) {
+      const { name, room: savedRoom } = JSON.parse(savedSession);
+      if (name && savedRoom) {
+        setUsername(name);
+        setRoom(savedRoom);
+        setIsLoggedIn(true);
+        // By setting pendingJoinRef, the socket useEffect will handle joining the room
+        // once the connection is established.
+        pendingJoinRef.current = { room: savedRoom, username: name };
+      }
+    }
+  }, []); // Run only on initial mount
 
   useEffect(() => {
     const newSocket = io(getSocketUrl(), {
@@ -142,6 +158,10 @@ function App() {
     }
 
     setUsername(nextUsername);
+
+    // Save session to localStorage
+    const sessionData = { name: nextUsername, room: nextRoom };
+    localStorage.setItem('chatSession', JSON.stringify(sessionData));
   };
 
   const handleLogin = (e) => {
@@ -184,6 +204,8 @@ function App() {
     setIsLoggedIn(false);
     setRoom('');
     setMessages([]);
+    // Clear the session from storage
+    localStorage.removeItem('chatSession');
   };
 
   if (!isLoggedIn) {

--- a/client/src/GoogleSignIn.js
+++ b/client/src/GoogleSignIn.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
+import { jwtDecode } from 'jwt-decode';
 
 const GoogleSignIn = ({ onSignIn }) => {
     const handleSuccess = (credentialResponse) => {
         try {
             // Decode the JWT token to extract the user's Google info
-            const payloadBase64 = credentialResponse.credential.split('.')[1];
-            const decodedJson = atob(payloadBase64);
-            const payload = JSON.parse(decodedJson);
+            const payload = jwtDecode(credentialResponse.credential);
             
             if (payload && payload.name) {
                 onSignIn({ name: payload.name, email: payload.email, picture: payload.picture });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.22.2",
         "google-auth-library": "^10.6.2",
+        "jwt-decode": "^4.0.0",
         "mongoose": "^8.5.1",
         "socket.io": "^4.7.5"
       },
@@ -1194,6 +1195,15 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/kareem": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.22.2",
     "google-auth-library": "^10.6.2",
+    "jwt-decode": "^4.0.0",
     "mongoose": "^8.5.1",
     "socket.io": "^4.7.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,11 @@ jws@^4.0.0:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 kareem@2.6.3:
   version "2.6.3"
   resolved "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz"


### PR DESCRIPTION
fix(client): persist user session to prevent logout on refresh

Previously, the user's session, including their username and room, was stored only in React's in-memory state. This caused the user to be logged out every time the page was refreshed, leading to a poor user experience as described in issues #25 and #8.

This change introduces session persistence using the browser's localStorage.

- On joining a room, the user's name and room are saved to localStorage.
- On initial application load, a useEffect hook checks for a saved session and automatically restores the user's state, re-joining them to their last room.
- When the user explicitly leaves a room, the session data is cleared from localStorage.

Closes #25, Closes #8